### PR TITLE
Fixed wrong subject name in comments

### DIFF
--- a/spec/13_input_output_spec.rb
+++ b/spec/13_input_output_spec.rb
@@ -115,7 +115,7 @@ describe NumberGame do
   describe '#player_turn' do
     # In order to test the behavior of #player_turn, we need to use a method
     # stub for #player_input to return a valid_input ('3'). To stub a method,
-    # we 'allow' the test subject (player_game) to receive the :method_name
+    # we 'allow' the test subject (game_loop) to receive the :method_name
     # and to return a specific value.
     # https://relishapp.com/rspec/rspec-mocks/v/2-14/docs/method-stubs/allow-with-a-simple-return-value
     # http://testing-for-beginners.rubymonstas.org/test_doubles.html

--- a/spec_answers/13_input_output_answer.rb
+++ b/spec_answers/13_input_output_answer.rb
@@ -124,7 +124,7 @@ describe NumberGame do
   describe '#player_turn' do
     # In order to test the behavior of #player_turn, we need to use a method
     # stub for #player_input to return a valid_input ('3'). To stub a method,
-    # we 'allow' the test subject (player_game) to receive the :method_name
+    # we 'allow' the test subject (game_loop) to receive the :method_name
     # and to return a specific value.
     # https://relishapp.com/rspec/rspec-mocks/v/2-14/docs/method-stubs/allow-with-a-simple-return-value
     # http://testing-for-beginners.rubymonstas.org/test_doubles.html


### PR DESCRIPTION
The comments for 13_input_output_spec.rb cite the test subject as "player_game" but the actual tests use the subject name of "game_loop". I changed the comments to reflect the actual test subject name both in the spec file and spec answer file. 