### PR TITLE
Change ``describe '#display_range'

### DIFF
--- a/spec/15a_binary_game_spec.rb
+++ b/spec/15a_binary_game_spec.rb
@@ -361,7 +361,7 @@ describe BinaryGame do
     # Only contains puts statements -> No test necessary & can be private.
   end
 
-  describe '#display_range' do
+  describe '#display_guess' do
     # Located inside #display_binary_search (Looping Script Method)
     # Only contains puts statements -> No test necessary & can be private.
   end


### PR DESCRIPTION
Change ``describe '#display_range' to `describe #display_guess` 
At line 364, the method referenced is in binary_game is called `display_guess` not `display_range`