### PR TITLE
Fix: Add stubbing for external system calls

### DIFF
--- a/spec/16a_caesar_breaker_spec.rb
+++ b/spec/16a_caesar_breaker_spec.rb
@@ -62,67 +62,95 @@ describe CaesarBreaker do
   describe '#save_decrypted_messages' do
     # Located inside #decrypt (Public Script Method)
 
+    # Method with Outgoing Commands -> Test that the messages are sent
+    context 'when the directory does not exist' do
+      # We need to stub several outgoing commands that communicate with
+      # external systems and create the conditions for this test. In addition,
+      # there are puts statements in #display_file_location so let's stub that
+      # method to clean up the test output.
+      before do
+        allow(Dir).to receive(:exist?).and_return(false)
+        allow(Dir).to receive(:mkdir)
+        allow(File).to receive(:open)
+        allow(phrase).to receive(:display_file_location)
+      end
+
+      # ASSIGNMENT #2
+      # Write the following 3 tests:
+
+      xit 'sends message to check the existance of the 16_cipher directory' do
+      end
+
+      xit 'sends message to create a directory' do
+      end
+
+      xit 'sends message to create a file' do
+      end
+    end
+
+    # ASSIGNMENT #3
+    # Write the following 3 tests and the shared before block:
+
+    # Method with Outgoing Commands -> Test that the messages are sent
+    context 'when the directory exists' do
+      before do
+      end
+
+      xit 'sends message to check the existance of the 16_cipher directory' do
+      end
+
+      xit 'does not send message to create a directory' do
+      end
+
+      xit 'sends message to create a file' do
+      end
+    end
+
     # This method has a rescue block in case an error occurs.
     # Let's test that this method can run without raising an error.
     # https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/raise-error-matcher
 
-    context 'when it saves a file' do
-      # The tests in this context block will output two puts statements from
-      # #display_file_location. So let's stub out that method to clean up the
-      # test output.
+    context 'when file is saved successfully' do
       before do
+        allow(Dir).to receive(:exist?).and_return(false)
+        allow(Dir).to receive(:mkdir)
+        allow(File).to receive(:open)
         allow(phrase).to receive(:display_file_location)
       end
 
       it 'does not raise an error' do
         expect { phrase.save_decrypted_messages }.not_to raise_error
       end
-
-      # ASSIGNMENT #2
-
-      # Write the following 3 tests:
-
-      # Method with Outgoing Command -> Test that a message is sent
-      xit 'opens a new File' do
-      end
-
-      # Method with Outgoing Command -> Test that a message is sent
-      xit 'makes new directory' do
-      end
-
-      xit 'does not make new directory' do
-      end
     end
 
     # Let's simulate an error occuring during #save_decrypted_messages by
     # allowing File.open to raise the error 'Errno::ENOENT'. This error means
-    # that no such file or directory could be found.
+    # that no such file or directory could be found. In addition, when an error
+    # is rescued there are two puts to stub to clean up the test output.
     context 'when rescuing an error' do
       before do
+        allow(Dir).to receive(:exist?).and_return(false)
+        allow(Dir).to receive(:mkdir)
         allow(File).to receive(:open).and_raise(Errno::ENOENT)
         allow(phrase).to receive(:puts).twice
       end
 
       # When an error is rescued, the method will not raise an error. Therefore
       # you test the conditions that would occur if an error were rescued.
-      it 'does not raise an error' do
-        expect { phrase.save_decrypted_messages }.not_to raise_error
-      end
-
       it 'does not display file location' do
         expect(phrase).not_to receive(:display_file_location)
         phrase.save_decrypted_messages
       end
 
-      it 'displays error rescue message' do
-        expect(phrase).to receive(:puts).twice
+      it 'outputs two error messages' do
+        expect(phrase).to receive(:puts).with('Error while writing to file LippsAsvph.yaml.')
+        expect(phrase).to receive(:puts).with(Errno::ENOENT)
         phrase.save_decrypted_messages
       end
     end
   end
 
-  # ASSIGNMENT #3
-
+  # ASSIGNMENT #4
   # Write the following test:
 
   describe '#save_to_yaml' do

--- a/spec_answers/16a_caesar_answer.rb
+++ b/spec_answers/16a_caesar_answer.rb
@@ -63,75 +63,110 @@ describe CaesarBreaker do
   describe '#save_decrypted_messages' do
     # Located inside #decrypt (Public Script Method)
 
+    # Method with Outgoing Commands -> Test that the messages are sent
+    context 'when the directory does not exist' do
+      # We need to stub several outgoing commands that communicate with
+      # external systems and create the conditions for this test. In addition,
+      # there are puts statements in #display_file_location so let's stub that
+      # method to clean up the test output.
+      before do
+        allow(Dir).to receive(:exist?).and_return(false)
+        allow(Dir).to receive(:mkdir)
+        allow(File).to receive(:open)
+        allow(phrase).to receive(:display_file_location)
+      end
+
+      # ASSIGNMENT #2
+      # Write the following 3 tests:
+
+      it 'sends message to check the existance of the 16_cipher directory' do
+        expect(Dir).to receive(:exist?).with('16_cipher').exactly(1).time
+        phrase.save_decrypted_messages
+      end
+
+      it 'sends message to create a directory' do
+        expect(Dir).to receive(:mkdir).exactly(1).time
+        phrase.save_decrypted_messages
+      end
+
+      it 'sends message to create a file' do
+        expect(File).to receive(:open).exactly(1).time
+        phrase.save_decrypted_messages
+      end
+    end
+
+    # ASSIGNMENT #3
+    # Write the following 3 tests and the shared before block:
+
+    # Method with Outgoing Commands -> Test that the messages are sent
+    context 'when the directory exists' do
+      before do
+        allow(Dir).to receive(:exist?).and_return(true)
+        allow(File).to receive(:open)
+        allow(phrase).to receive(:display_file_location)
+      end
+
+      it 'sends message to check the existance of the 16_cipher directory' do
+        expect(Dir).to receive(:exist?).with('16_cipher').exactly(1).time
+        phrase.save_decrypted_messages
+      end
+
+      it 'does not send message to create a directory' do
+        expect(Dir).not_to receive(:mkdir)
+        phrase.save_decrypted_messages
+      end
+
+      it 'sends message to create a file' do
+        expect(File).to receive(:open).exactly(1).time
+        phrase.save_decrypted_messages
+      end
+    end
+
     # This method has a rescue block in case an error occurs.
     # Let's test that this method can run without raising an error.
     # https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/raise-error-matcher
 
-    context 'when it saves a file' do
-      # The tests in this context block will output two puts statements from
-      # #display_file_location. So let's stub out that method to clean up the
-      # test output.
+    context 'when file is saved successfully' do
       before do
+        allow(Dir).to receive(:exist?).and_return(false)
+        allow(Dir).to receive(:mkdir)
+        allow(File).to receive(:open)
         allow(phrase).to receive(:display_file_location)
       end
 
       it 'does not raise an error' do
         expect { phrase.save_decrypted_messages }.not_to raise_error
       end
-
-      # ASSIGNMENT #2
-
-      # Write the following 3 tests:
-
-      # Method with Outgoing Command -> Test that a message is sent
-      it 'opens a new File' do
-        expect(File).to receive(:open)
-        phrase.save_decrypted_messages
-      end
-
-      # Method with Outgoing Command -> Test that a message is sent
-      it 'makes new directory' do
-        allow(Dir).to receive(:exist?).and_return(false)
-        expect(Dir).to receive(:mkdir)
-        phrase.save_decrypted_messages
-      end
-
-      it 'does not make new directory' do
-        allow(Dir).to receive(:exist?).and_return(true)
-        expect(Dir).not_to receive(:mkdir)
-        phrase.save_decrypted_messages
-      end
     end
 
     # Let's simulate an error occuring during #save_decrypted_messages by
     # allowing File.open to raise the error 'Errno::ENOENT'. This error means
-    # that no such file or directory could be found.
+    # that no such file or directory could be found. In addition, when an error
+    # is rescued there are two puts to stub to clean up the test output.
     context 'when rescuing an error' do
       before do
+        allow(Dir).to receive(:exist?).and_return(false)
+        allow(Dir).to receive(:mkdir)
         allow(File).to receive(:open).and_raise(Errno::ENOENT)
         allow(phrase).to receive(:puts).twice
       end
 
       # When an error is rescued, the method will not raise an error. Therefore
       # you test the conditions that would occur if an error were rescued.
-      it 'does not raise an error' do
-        expect { phrase.save_decrypted_messages }.not_to raise_error
-      end
-
       it 'does not display file location' do
         expect(phrase).not_to receive(:display_file_location)
         phrase.save_decrypted_messages
       end
 
-      it 'displays error rescue message' do
-        expect(phrase).to receive(:puts).twice
+      it 'outputs two error messages' do
+        expect(phrase).to receive(:puts).with('Error while writing to file LippsAsvph.yaml.')
+        expect(phrase).to receive(:puts).with(Errno::ENOENT)
         phrase.save_decrypted_messages
       end
     end
   end
 
-  # ASSIGNMENT #3
-
+  # ASSIGNMENT #4
   # Write the following test:
 
   describe '#save_to_yaml' do


### PR DESCRIPTION
Because:
* Prevents directory and file being created when tests run.

This Commit:
* Adds stubbing for external system calls.
* Organizes tests with more defined contexts.
* Creates a new assignment for students to complete.
* Updates the spec_answer file accordingly.