### PR TITLE
Updates Ruby version in readme of ruby_testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These lessons cover many topics, but it does not cover everything that RSpec is 
 - Test Driven Development
 
 ## Set-Up
-Run `rbenv versions` to confirm that you have ruby version 2.7.4 installed. If you do not have this version installed, please refer back to these [instructions](https://www.theodinproject.com/paths/full-stack-ruby-on-rails/courses/ruby-programming/lessons/installing-ruby-ruby-programming) to install it.
+Run `rbenv versions` to confirm that you have ruby version 3.0.3 installed. If you do not have this version installed, please refer back to these [instructions](https://www.theodinproject.com/paths/full-stack-ruby-on-rails/courses/ruby-programming/lessons/installing-ruby-ruby-programming) to install it.
 
 Run `bundle install` from the root directory.
 


### PR DESCRIPTION
Spec files require Ruby version 3.0.3 to run. Updated Set-Up section of readme to reflect that.