### PR TITLE
BinaryGame spec: Fix comment to change wrong method mentioned

### DIFF
--- a/spec/15a_binary_game_spec.rb
+++ b/spec/15a_binary_game_spec.rb
@@ -150,7 +150,7 @@ describe BinaryGame do
   # Create a new instance of BinaryGame and write a test for the following two
   # context blocks.
   describe '#verify_input' do
-    # Located inside #play_game (Looping Script Method)
+    # Located inside #player_input (Looping Script Method)
     # Query Method -> Test the return value
 
     # Note: #verify_input will only return a number if it is between?(min, max)

--- a/spec/15b_binary_search_spec.rb
+++ b/spec/15b_binary_search_spec.rb
@@ -18,7 +18,7 @@ require_relative '../lib/15c_random_number'
 
 # This spec file uses verifying doubles to help you get acquaintance with the
 # concept. Differently from the normal test double we've been using so far, 
-# a verifying double can produce an error if the method being stubbed do not
+# a verifying double can produce an error if the method being stubbed does not
 # exist in the actual class. Verifying doubles are a great tool to use when 
 # you're doing integration testing and need to make sure that different classes 
 # work together in order to fulfill some bigger computation.

--- a/spec/15b_binary_search_spec.rb
+++ b/spec/15b_binary_search_spec.rb
@@ -18,7 +18,7 @@ require_relative '../lib/15c_random_number'
 
 # This spec file uses verifying doubles to help you get acquaintance with the
 # concept. Differently from the normal test double we've been using so far, 
-# a verifying double can produce an error if the method being stubbed do not 
+# a verifying double can produce an error if the method being stubbed does not
 # exist in the actual class. Verifying doubles are a great tool to use when 
 # you're doing integration testing and need to make sure that different classes 
 # work together in order to fulfill some bigger computation.

--- a/spec/15b_binary_search_spec.rb
+++ b/spec/15b_binary_search_spec.rb
@@ -18,7 +18,7 @@ require_relative '../lib/15c_random_number'
 
 # This spec file uses verifying doubles to help you get acquaintance with the
 # concept. Differently from the normal test double we've been using so far, 
-# a verifying double can produce an error if the method being stubbed does not
+# a verifying double can produce an error if the method being stubbed do not
 # exist in the actual class. Verifying doubles are a great tool to use when 
 # you're doing integration testing and need to make sure that different classes 
 # work together in order to fulfill some bigger computation.

--- a/spec/16a_caesar_breaker_spec.rb
+++ b/spec/16a_caesar_breaker_spec.rb
@@ -40,6 +40,7 @@ describe CaesarBreaker do
   # Write a test for the following method.
 
   describe '#create_decrypted_messages' do
+    # This is a Looping Script Method.
     # Located inside #decrypt (Public Script Method)
 
     # Method with Outgoing Command -> Test that a message is sent

--- a/spec_answers/15a_binary_game_answer.rb
+++ b/spec_answers/15a_binary_game_answer.rb
@@ -167,7 +167,7 @@ describe BinaryGame do
   # Create a new instance of BinaryGame and write a test for the following two
   # context blocks.
   describe '#verify_input' do
-    # Located inside #play_game (Looping Script Method)
+    # Located inside #player_input (Looping Script Method)
     # Query Method -> Test the return value
 
     # NOTE: #verify_input will only return a number if it is between?(min, max)

--- a/spec_answers/16a_caesar_answer.rb
+++ b/spec_answers/16a_caesar_answer.rb
@@ -39,6 +39,7 @@ describe CaesarBreaker do
 
   # Write a test for the following method.
   describe '#create_decrypted_messages' do
+    # This is a Looping Script Method.
     # Located inside #decrypt (Public Script Method)
 
     # Method with Outgoing Command -> Test that a message is sent


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
There seems to be a misleading comment in the file `15a_binary_game_spec.rb` specifically about which method calls `#verify_input`. The comment describes its calling method `#play_game` as a "Looping Script Method" which is actually for describing `#player_input`.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- **Files** `15a_binary_game_spec.rb` and `15a_binary_game_answer.rb`
  - **Example Group** `describe '#verify_input' do`
    - Change `#play_game` to `#player_input`
- **Files** `16a_caesar_breaker_spec.rb` and `16a_caesar_answer.rb`
  - **Example Group** `describe '#create_decrypted_messages' do`
    - Add comment `# This is a Looping Script Method.`
- **File** `15b_binary_search_spec.rb`
  - In introductory comments, fix 'do' to 'does' in `# a verifying double can produce an error if the method being stubbed do not`

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `String spec: Update instructions for clarity`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes changes in the `spec` folder, they are also updated in the corresponding file in the `spec_answers` folder (with passing tests).
