### PR TITLE
fix: use webarchive for relishapp links

### DIFF
--- a/spec/02_array_spec.rb
+++ b/spec/02_array_spec.rb
@@ -3,7 +3,7 @@
 describe Array do
   # An implicitly defined 'subject' is available when the outermost example
   # group is a class. The 'subject' will be an instance of that class.
-  # https://relishapp.com/rspec/rspec-core/v/2-11/docs/subject/implicitly-defined-subject
+  # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-core/v/2-11/docs/subject/implicitly-defined-subject
 
   # Note: Using an implicit subject is not recommended for most situations.
   # The next lesson will cover explicit subjects, which are recommended over
@@ -11,7 +11,7 @@ describe Array do
 
   context 'when subject is implicitly defined' do
     # Type matchers can use be_a or be_an to increase readability.
-    # https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/type-matchers
+    # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/type-matchers
     it 'is an Array' do
       expect(subject).to be_an(Array)
     end
@@ -31,7 +31,7 @@ describe Array do
     end
     
     # RSpec can leverage this to create predicate matchers for any predicate method.
-    # https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/predicate-matchers
+    # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/predicate-matchers
     it 'is empty' do
       expect(subject).to be_empty
     end
@@ -61,7 +61,7 @@ describe Array do
 
   # The answer is that each group runs its examples before running its nested
   # example groups, even if the nested groups are defined before the examples.
-  # https://relishapp.com/rspec/rspec-core/v/3-9/docs/command-line/order
+  # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-core/v/3-9/docs/command-line/order
 
   # Please note: one-line tests are only recommended when the matcher aligns
   # exactly with the doc string. Even in that case, many rubyists prefer

--- a/spec/03_number_spec.rb
+++ b/spec/03_number_spec.rb
@@ -17,14 +17,14 @@ describe SingleDigit do
 
   # It is recommended to explicitly define the subject with a descriptive name.
   # Then use the descriptive name, instead of 'subject,' in the tests.
-  # https://relishapp.com/rspec/rspec-core/docs/subject/explicit-subject
+  # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-core/docs/subject/explicit-subject
   subject(:random_digit) { SingleDigit.new }
 
   # There can be multiple tests in one example block; however, it is recommended
   # to test only one thing at a time.
   it 'is greater than or equal to 1' do
     # Comparison matchers are used with 'be' matcher
-    # https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/comparison-matchers
+    # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/comparison-matchers
     expect(random_digit.number).to be >= 1
   end
 

--- a/spec/04_hash_spec.rb
+++ b/spec/04_hash_spec.rb
@@ -5,7 +5,7 @@ describe Hash do
 
   # As you discovered in the last assignment, the include matcher works on any
   # object that would respond to the #include? method.
-  # https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/include-matcher
+  # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/include-matcher
   context 'when changing favorite color to forest green' do
     it 'includes green' do
       favorites[:color] = 'forest green'

--- a/spec/08_change_spec.rb
+++ b/spec/08_change_spec.rb
@@ -12,7 +12,7 @@ describe Array do
 
   # When testing for a change to occur, notice that unlike previous matchers
   # we've seen, 'change' accepts a block of code.
-  # https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/change-matcher
+  # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/change-matcher
 
   context 'when testing for a change' do
     it 'will change the length to 4' do

--- a/spec/09_custom_matcher_spec.rb
+++ b/spec/09_custom_matcher_spec.rb
@@ -2,7 +2,7 @@
 
 # If you need to test a condition that does not have a built-in matcher,
 # you can create your own.
-# https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/custom-matchers
+# https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/custom-matchers
 
 describe 'defining custom matchers' do
   context 'when reusing a matcher that is in scope' do

--- a/spec/11a_shared_example_spec.rb
+++ b/spec/11a_shared_example_spec.rb
@@ -10,7 +10,7 @@
 # 3. Complete either spec/11b_cat_spec.rb or spec/11c_dog_spec.rb
 
 # Start with reading about the use of shared examples:
-# https://relishapp.com/rspec/rspec-core/docs/example-groups/shared-examples
+# https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-core/docs/example-groups/shared-examples
 
 # These tests are dependent on using the implicit 'subject' when they are
 # included in another spec file. This file is not intended to be used alone.
@@ -20,7 +20,7 @@
 RSpec.shared_examples 'base class method name' do
   # This test can be used in Cat and Dog because the method comes from the
   # base class.
-  # https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/respond-to-matcher
+  # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/respond-to-matcher
   context 'when method is from the base class' do
     it 'responds to meal_time' do
       expect(subject).to respond_to(:meal_time)

--- a/spec/11b_cat_spec.rb
+++ b/spec/11b_cat_spec.rb
@@ -23,7 +23,7 @@ describe Cat do
   end
 
   context 'when cat has name and breed, but no color' do
-    # https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/have-attributes-matcher
+    # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/have-attributes-matcher
     it 'has name, breed & color attributes' do
       expect(oscar).to have_attributes(name: 'Oscar', breed: 'Maine Coon', color: nil)
     end

--- a/spec/11c_dog_spec.rb
+++ b/spec/11c_dog_spec.rb
@@ -23,7 +23,7 @@ describe Dog do
   end
 
   context 'when dog has name and color, but no breed' do
-    # https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/have-attributes-matcher
+    # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/have-attributes-matcher
     it 'has name, breed & color attributes' do
       expect(toby).to have_attributes(name: 'Toby', breed: nil, color: 'brown')
     end

--- a/spec/13_input_output_spec.rb
+++ b/spec/13_input_output_spec.rb
@@ -117,7 +117,7 @@ describe NumberGame do
     # stub for #player_input to return a valid_input ('3'). To stub a method,
     # we 'allow' the test subject (game_loop) to receive the :method_name
     # and to return a specific value.
-    # https://relishapp.com/rspec/rspec-mocks/v/2-14/docs/method-stubs/allow-with-a-simple-return-value
+    # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/v/2-14/docs/method-stubs/allow-with-a-simple-return-value
     # http://testing-for-beginners.rubymonstas.org/test_doubles.html
 
     subject(:game_loop) { described_class.new }
@@ -126,7 +126,7 @@ describe NumberGame do
       # To test the behavior, we want to test that the loop stops before the
       # puts 'Input error!' line. In order to test that this method is not
       # called, we use a message expectation.
-      # https://relishapp.com/rspec/rspec-mocks/docs
+      # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/docs
 
       it 'stops loop and does not display error message' do
         valid_input = '3'
@@ -140,12 +140,12 @@ describe NumberGame do
     context 'when user inputs an incorrect value once, then a valid input' do
       # As the 'Arrange' step for tests grows, you can use a before hook to
       # separate the test from the set-up.
-      # https://relishapp.com/rspec/rspec-core/v/2-0/docs/hooks/before-and-after-hooks\
+      # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-core/v/2-0/docs/hooks/before-and-after-hooks\
       # https://www.tutorialspoint.com/rspec/rspec_hooks.htm
 
       before do
         # A method stub can be called multiple times and return different values.
-        # https://relishapp.com/rspec/rspec-mocks/docs/configuring-responses/returning-a-value
+        # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/docs/configuring-responses/returning-a-value
         # This method stub for :player_input will return the invalid 'letter' input,
         # then it will return the 'valid_input'
         letter = 'd'
@@ -155,7 +155,7 @@ describe NumberGame do
 
       # When using message expectations, you can specify how many times you
       # expect the message to be received.
-      # https://relishapp.com/rspec/rspec-mocks/docs/setting-constraints/receive-counts
+      # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/docs/setting-constraints/receive-counts
       it 'completes loop and displays error message once' do
         expect(game_loop).to receive(:puts).with('Input error!').once
         game_loop.player_turn
@@ -180,7 +180,7 @@ describe NumberGame do
   # applications' don't even output like this except to loggers.
 
   # However, here is an example of how to test 'puts' using the output matcher.
-  # https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/output-matcher
+  # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/output-matcher
 
   describe '#final_message' do
     context 'when count is 1' do

--- a/spec/14_find_number_spec.rb
+++ b/spec/14_find_number_spec.rb
@@ -21,7 +21,7 @@ require_relative '../lib/14_find_number'
 
 # Note: the 'RandomNumber' class has not been written. During TDD, we will need
 # to create a double for RandomNumber in the tests for FindNumber.
-# https://relishapp.com/rspec/rspec-mocks/v/3-9/docs/basics/test-doubles
+# https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/v/3-9/docs/basics/test-doubles
 
 # Learning about doubles can be very confusing, because many resources use
 # doubles/mocks/stubs interchangeably. If you want to dig a little deeper,

--- a/spec/15a_binary_game_spec.rb
+++ b/spec/15a_binary_game_spec.rb
@@ -126,7 +126,7 @@ describe BinaryGame do
     # between the min & max integers) and one valid input number (as a string).
 
     # Remember that a stub can be called multiple times and return different values.
-    # https://relishapp.com/rspec/rspec-mocks/docs/configuring-responses/returning-a-value
+    # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/docs/configuring-responses/returning-a-value
 
     context 'when user inputs an incorrect value once, then a valid input' do
       before do
@@ -190,7 +190,7 @@ describe BinaryGame do
       # great tool to use when you're doing integration testing and need to make
       # sure that different classes work together in order to fulfill some bigger
       # computation.
-      # https://relishapp.com/rspec/rspec-mocks/v/3-9/docs/verifying-doubles
+      # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/v/3-9/docs/verifying-doubles
 
       # You should not use verifying doubles for unit testings. Unit testing relies 
       # on using doubles to test the object in isolation (i.e., not dependent on any
@@ -212,7 +212,7 @@ describe BinaryGame do
       # and will need to return the new_number. We are going to match the
       # literal arguments, but there are many ways to specify the arguments
       # using matching arguments:
-      # https://relishapp.com/rspec/rspec-mocks/docs/setting-constraints/matching-arguments
+      # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/docs/setting-constraints/matching-arguments
 
       before do
         allow(game_update).to receive(:puts)

--- a/spec/15b_binary_search_spec.rb
+++ b/spec/15b_binary_search_spec.rb
@@ -22,7 +22,7 @@ require_relative '../lib/15c_random_number'
 # exist in the actual class. Verifying doubles are a great tool to use when 
 # you're doing integration testing and need to make sure that different classes 
 # work together in order to fulfill some bigger computation.
-# https://relishapp.com/rspec/rspec-mocks/v/3-9/docs/verifying-doubles
+# https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/v/3-9/docs/verifying-doubles
 
 # You should not use verifying doubles for unit testings. Unit testing relies 
 # on using doubles to test the object in isolation (i.e., not dependent on any

--- a/spec/16a_caesar_breaker_spec.rb
+++ b/spec/16a_caesar_breaker_spec.rb
@@ -52,7 +52,7 @@ describe CaesarBreaker do
   # (The following methods are located in lib/16c_database.rb)
 
   # Some prefer explicitly including it in the configuration option.
-  # https://relishapp.com/rspec/rspec-core/docs/helper-methods/define-helper-methods-in-a-module
+  # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-core/docs/helper-methods/define-helper-methods-in-a-module
 
   # Some prefer testing modules using a dummy class.
   # https://mixandgo.com/learn/how-to-test-ruby-modules-with-rspec
@@ -109,7 +109,7 @@ describe CaesarBreaker do
 
     # This method has a rescue block in case an error occurs.
     # Let's test that this method can run without raising an error.
-    # https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/raise-error-matcher
+    # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/raise-error-matcher
 
     context 'when file is saved successfully' do
       before do

--- a/spec_answers/11b_cat_answer.rb
+++ b/spec_answers/11b_cat_answer.rb
@@ -14,7 +14,7 @@ describe Cat do
   end
 
   context 'when cat has name and breed, but no color' do
-    # https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/have-attributes-matcher
+    # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/have-attributes-matcher
     it 'has name, breed & color attributes' do
       expect(oscar).to have_attributes(name: 'Oscar', breed: 'Maine Coon', color: nil)
     end

--- a/spec_answers/11c_dog_answer.rb
+++ b/spec_answers/11c_dog_answer.rb
@@ -14,7 +14,7 @@ describe Dog do
   end
 
   context 'when dog has name and color, but no breed' do
-    # https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/have-attributes-matcher
+    # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/v/3-9/docs/built-in-matchers/have-attributes-matcher
     it 'has name, breed & color attributes' do
       expect(toby).to have_attributes(name: 'Toby', breed: nil, color: 'brown')
     end

--- a/spec_answers/13_input_output_answer.rb
+++ b/spec_answers/13_input_output_answer.rb
@@ -124,7 +124,7 @@ describe NumberGame do
     # stub for #player_input to return a valid_input ('3'). To stub a method,
     # we 'allow' the test subject (game_loop) to receive the :method_name
     # and to return a specific value.
-    # https://relishapp.com/rspec/rspec-mocks/v/2-14/docs/method-stubs/allow-with-a-simple-return-value
+    # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/v/2-14/docs/method-stubs/allow-with-a-simple-return-value
     # http://testing-for-beginners.rubymonstas.org/test_doubles.html
 
     subject(:game_loop) { described_class.new }
@@ -133,7 +133,7 @@ describe NumberGame do
       # To test the behavior, we want to test that the loop stops before the
       # puts 'Input error!' line. In order to test that this method is not
       # called, we use a message expectation.
-      # https://relishapp.com/rspec/rspec-mocks/docs
+      # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/docs
 
       it 'stops loop and does not display error message' do
         valid_input = '3'
@@ -146,13 +146,13 @@ describe NumberGame do
 
     context 'when user inputs an incorrect value once, then a valid input' do
       # A method stub can be called multiple times and return different values.
-      # https://relishapp.com/rspec/rspec-mocks/docs/configuring-responses/returning-a-value
+      # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/docs/configuring-responses/returning-a-value
       # Create a stub method to receive :player_input and return the invalid
       # 'letter' input, then the 'valid_input'
 
       # As the 'Arrange' step for tests grows, you can use a before hook to
       # separate the test from the set-up.
-      # https://relishapp.com/rspec/rspec-core/v/2-0/docs/hooks/before-and-after-hooks\
+      # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-core/v/2-0/docs/hooks/before-and-after-hooks\
       # https://www.tutorialspoint.com/rspec/rspec_hooks.htm
       before do
         letter = 'd'
@@ -162,7 +162,7 @@ describe NumberGame do
 
       # When using message expectations, you can specify how many times you
       # expect the message to be received.
-      # https://relishapp.com/rspec/rspec-mocks/docs/setting-constraints/receive-counts
+      # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/docs/setting-constraints/receive-counts
       it 'completes loop and displays error message once' do
         expect(game_loop).to receive(:puts).with('Input error!').once
         game_loop.player_turn
@@ -193,7 +193,7 @@ describe NumberGame do
   # applications' don't even output like this except to loggers.
 
   # However, here is an example of how to test 'puts' using the output matcher.
-  # https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/output-matcher
+  # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/output-matcher
 
   describe '#final_message' do
     context 'when count is 1' do

--- a/spec_answers/15a_binary_game_answer.rb
+++ b/spec_answers/15a_binary_game_answer.rb
@@ -126,7 +126,7 @@ describe BinaryGame do
     # between the min & max integers) and one valid input number (as a string).
 
     # Remember that a stub can be called multiple times and return different values.
-    # https://relishapp.com/rspec/rspec-mocks/docs/configuring-responses/returning-a-value
+    # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/docs/configuring-responses/returning-a-value
 
     context 'when user inputs an incorrect value once, then a valid input' do
       before do
@@ -219,7 +219,7 @@ describe BinaryGame do
       # great tool to use when you're doing integration testing and need to make
       # sure that different classes work together in order to fulfill some bigger
       # computation.
-      # https://relishapp.com/rspec/rspec-mocks/v/3-9/docs/verifying-doubles
+      # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/v/3-9/docs/verifying-doubles
 
       # You should not use verifying doubles for unit testings. Unit testing relies
       # on using doubles to test the object in isolation (i.e., not dependent on any
@@ -241,7 +241,7 @@ describe BinaryGame do
       # and will need to return the new_number. We are going to match the
       # literal arguments, but there are many ways to specify the arguments
       # using matching arguments:
-      # https://relishapp.com/rspec/rspec-mocks/docs/setting-constraints/matching-arguments
+      # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-mocks/docs/setting-constraints/matching-arguments
 
       before do
         allow(game_update).to receive(:puts)

--- a/spec_answers/16a_caesar_answer.rb
+++ b/spec_answers/16a_caesar_answer.rb
@@ -53,7 +53,7 @@ describe CaesarBreaker do
   # (The following methods are located in lib/16c_database.rb)
 
   # Some prefer explicitly including it in the configuration option.
-  # https://relishapp.com/rspec/rspec-core/docs/helper-methods/define-helper-methods-in-a-module
+  # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-core/docs/helper-methods/define-helper-methods-in-a-module
 
   # Some prefer testing modules using a dummy class.
   # https://mixandgo.com/learn/how-to-test-ruby-modules-with-rspec
@@ -125,7 +125,7 @@ describe CaesarBreaker do
 
     # This method has a rescue block in case an error occurs.
     # Let's test that this method can run without raising an error.
-    # https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/raise-error-matcher
+    # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/raise-error-matcher
 
     context 'when file is saved successfully' do
       before do


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The RelishApp documentation links in this repository currently aren't working.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Replaces the RelishApp links throughout the repository with links to a webarchive snapshot to the RelishApp

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #41 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `String spec: Update instructions for clarity`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes changes in the `spec` folder, they are also updated in the corresponding file in the `spec_answers` folder (with passing tests).
