### PR TITLE
BinaryGame spec: Fix comment to correctly describe a tested method's type

### DIFF
--- a/spec/15a_binary_game_spec.rb
+++ b/spec/15a_binary_game_spec.rb
@@ -320,8 +320,11 @@ describe BinaryGame do
 
   # Write three tests for the following method.
   describe '#display_turn_order' do
-    # This method is a Looping Script Method. In #display_binary_search,
-    # #display_turn_order will loop until binary_search.game_over?
+    # This method is both a Command Method and a Script Method. It changes the
+    # observable state by incrementing the instance variable @guess_count by one,
+    # sends two command messages #make_guess and #update_range to the object
+    # binary_search of class BinarySearch, and sends one command message to `self`
+    #  by calling #display_guess.
 
     # Create a new subject and an instance_double for BinarySearch.
 

--- a/spec_answers/15a_binary_game_answer.rb
+++ b/spec_answers/15a_binary_game_answer.rb
@@ -359,8 +359,11 @@ describe BinaryGame do
 
   # Write three tests for the following method.
   describe '#display_turn_order' do
-    # This method is a Looping Script Method. In #display_binary_search,
-    # #display_turn_order will loop until binary_search.game_over?
+    # This method is both a Command Method and a Script Method. It changes the
+    # observable state by incrementing the instance variable @guess_count by one,
+    # sends two command messages #make_guess and #update_range to the object
+    # binary_search of class BinarySearch, and sends one command message to `self`
+    #  by calling #display_guess.
 
     # Create a new subject and an instance_double for BinarySearch.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
Fixes the comment describing the method type for the method `#display_turn_order` in the file **spec/15a_binary_game_spec.rb**.

## This PR
- Fix comment right below `describe #display_turn_order do` describing the method type.

## Issue
Closes #40 

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `String spec: Update instructions for clarity`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes changes in the `spec` folder, they are also updated in the corresponding file in the `spec_answers` folder (with passing tests).
