### PR TITLE
Update Implicitly Defined Subject documentation link

### DIFF
--- a/spec/02_array_spec.rb
+++ b/spec/02_array_spec.rb
@@ -3,7 +3,7 @@
 describe Array do
   # An implicitly defined 'subject' is available when the outermost example
   # group is a class. The 'subject' will be an instance of that class.
-  # https://web.archive.org/web/20230101143200/https://relishapp.com/rspec/rspec-core/v/2-11/docs/subject/implicitly-defined-subject
+  # https://web.archive.org/web/20221204015051/https://relishapp.com/rspec/rspec-core/v/3-9/docs/subject/implicitly-defined-subject
 
   # Note: Using an implicit subject is not recommended for most situations.
   # The next lesson will cover explicit subjects, which are recommended over


### PR DESCRIPTION
## Because
The link was outdated and used `should` which is deprecated.


## This PR
* Updated the link from 2.11 to 3.9


## Issue
Closes #45

## Additional Information


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `String spec: Update instructions for clarity`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If this PR includes changes in the `spec` folder, they are also updated in the corresponding file in the `spec_answers` folder (with passing tests).
