### PR TITLE
Binary Search spec: Use verifying doubles consistently where introduced

### DIFF
--- a/spec/15b_binary_search_spec.rb
+++ b/spec/15b_binary_search_spec.rb
@@ -17,18 +17,18 @@ require_relative '../lib/15c_random_number'
 # has been renamed to BinarySearch, which is a more accurate description.
 
 # This spec file uses verifying doubles to help you get acquaintance with the
-# concept. Differently from the normal test double we've been using so far, 
+# concept. Differently from the normal test double we've been using so far,
 # a verifying double can produce an error if the method being stubbed does not
-# exist in the actual class. Verifying doubles are a great tool to use when 
-# you're doing integration testing and need to make sure that different classes 
+# exist in the actual class. Verifying doubles are a great tool to use when
+# you're doing integration testing and need to make sure that different classes
 # work together in order to fulfill some bigger computation.
 # https://rspec.info/features/3-12/rspec-mocks/verifying-doubles/
 
-# You should not use verifying doubles for unit testings. Unit testing relies 
+# You should not use verifying doubles for unit testings. Unit testing relies
 # on using doubles to test the object in isolation (i.e., not dependent on any
-# other object). One important concept to understand is that the BinarySearch 
+# other object). One important concept to understand is that the BinarySearch
 # or FindNumber class doesn't care if it is given an actual random_number class
-# object. It only cares that it is given an object that can respond to certain 
+# object. It only cares that it is given an object that can respond to certain
 # methods. This concept is called polymorphism.
 # https://www.geeksforgeeks.org/polymorphism-in-ruby/
 
@@ -96,7 +96,7 @@ describe BinarySearch do
     end
 
     context 'when guess and random_number are not equal' do
-      let(:mid_number) { double('random_number', value: 5) }
+      let(:mid_number) { instance_double(RandomNumber, value: 5) }
       subject(:mid_game) { described_class.new(0, 9, mid_number, 4) }
 
       it 'is not game over' do
@@ -106,7 +106,7 @@ describe BinarySearch do
   end
 
   describe '#update_range' do
-    let(:range_number) { double('random_number', value: 8) }
+    let(:range_number) { instance_double(RandomNumber, value: 8) }
 
     context 'when the guess is less than the answer' do
       subject(:low_guess_game) { described_class.new(0, 9, range_number, 4) }


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
- This file, 15b_binary_search_spec.rb, as explained in its comments, "uses verifying doubles to help you get acqauintance with the concept". But it replaces only 2 of the file's 4 doubles with verifying doubles.
- The inconsistency is not explained, so it creates unnecessary confusion.
- For what it's worth, a related file, 15a_binary_game_spec, uses verifying doubles consistently.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Removes the unexplained inconsistency from 15b by replacing the remaining 2 doubles with verifying doubles.
- (Also removes some trailing spaces. Not sure if Prettier or RuboCop deserves credit/blame. Hopefully not a problem.)

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
N/A
## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
I found a [Discord discussion](https://discord.com/channels/505093832157691914/704694487477387344/1024422128197587046) where a student mentioned confusion about this inconsistency and @rlmoser99 invited a PR, but it looks like none was made.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `String spec: Update instructions for clarity`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes changes in the `spec` folder, they are also updated in the corresponding file in the `spec_answers` folder (with passing tests). [N/A, as this file is informational and has no corresponding answer file]
