### PR TITLE
./spec/14_find_number_spec.rb : Fix spelling error on line 6.

### DIFF
--- a/spec/14_find_number_spec.rb
+++ b/spec/14_find_number_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../lib/14_find_number'
 
 # The file order to complete this lesson:
-# 1. Familarize yourself with the initialize method in lib/14_find_number.rb
+# 1. Familiarize yourself with the initialize method in lib/14_find_number.rb
 # 2. Start reading spec/14_find_number_spec.rb, which will also include
 #    instructions to add methods to lib/14_find_number.rb
 


### PR DESCRIPTION

## Because
There is a spelling error on ./spec/14_find_number_spec.rb  line 6.


## This PR
- Fixes the above mentioned error. 


## Issue

Closes #53 

## Additional Information



## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `String spec: Update instructions for clarity`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes changes in the `spec` folder, they are also updated in the corresponding file in the `spec_answers` folder (with passing tests).
