### PR TITLE
Spec 05: Fix link to Eddy Luten article

### DIFF
--- a/spec/05_truthy_falsy_spec.rb
+++ b/spec/05_truthy_falsy_spec.rb
@@ -2,7 +2,7 @@
 
 # Do not use 'be_truthy' or 'be_falsy' for methods that should only be
 # evaluated into a Boolean.
-# https://eddyluten.com/rspec-be_truthy-exists-or-be-true
+# https://luten.dev/rspec-be_truthy-exists-or-be-true/
 
 describe 'truthy and falsy' do
   context 'almost everything is truthy' do


### PR DESCRIPTION
## Because
Link in spec/05 is broken. I've replaced it with (I believe) is a new link to the same article from the same person

## This PR
- Fixes the link to article "RSpec be_truthy, exist, or be true?" in spec/05

## Issue
N/A

## Additional Information
N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `String spec: Update instructions for clarity`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes changes in the `spec` folder, they are also updated in the corresponding file in the `spec_answers` folder (with passing tests).
