### PR TITLE
Input output spec: Add resource 

### DIFF
--- a/spec/13_input_output_spec.rb
+++ b/spec/13_input_output_spec.rb
@@ -119,6 +119,7 @@ describe NumberGame do
     # and to return a specific value.
     # https://rspec.info/features/3-12/rspec-mocks/basics/allowing-messages/
     # http://testing-for-beginners.rubymonstas.org/test_doubles.html
+    # https://edpackard.medium.com/the-no-problemo-basic-guide-to-doubles-and-stubs-in-rspec-1af3e13b158
 
     subject(:game_loop) { described_class.new }
 


### PR DESCRIPTION
## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Add beginner-friendly resource on RSpec stub and mock.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- The resource [The ‘no problemo’ basic guide to doubles and stubs in RSpec](https://edpackard.medium.com/the-no-problemo-basic-guide-to-doubles-and-stubs-in-rspec-1af3e13b158) is added to the stub/mock section of Exercise `13_input_output_spec.rb`.


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #60 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `String spec: Update instructions for clarity`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes changes in the `spec` folder, they are also updated in the corresponding file in the `spec_answers` folder (with passing tests).
