### PR TITLE
README: remove hardcoded Ruby version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These lessons cover many topics, but it does not cover everything that RSpec is 
 - Test Driven Development
 
 ## Set-Up
-Run `rbenv versions` to confirm that you have ruby version 3.2.2 installed. If you do not have this version installed, please refer back to these [instructions](https://www.theodinproject.com/lessons/ruby-installing-ruby) to install it.
+Run `rbenv versions` to confirm that you have the same Ruby version installed as the one indicated in the `.ruby-version` file. If you do not have this version installed, please refer back to these [instructions](https://www.theodinproject.com/lessons/ruby-installing-ruby) to install it.
 
 Run `bundle install` from the root directory.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The version in the README is outdated compared to `.ruby-version`. 
By refering to `.ruby-version` instead, we avoid the need to manually update the README whenever the Ruby version changes. 

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
* Replaces the specifc Ruby version in the README with telling the user to check for a matchng ruby version in `.ruby-version`.

## Issue

Closes #64


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `String spec: Update instructions for clarity`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If this PR includes changes in the `spec` folder, they are also updated in the corresponding file in the `spec_answers` folder (with passing tests).
