### PR TITLE
Rspec exercise: Fix broken links in 12_magic_seven_spec.rb

### DIFF
--- a/spec/12_magic_seven_spec.rb
+++ b/spec/12_magic_seven_spec.rb
@@ -8,7 +8,7 @@ require_relative '../lib/12_magic_seven'
 
 # Before learning any more complexities of testing, let's take a look at a
 # standard testing pattern: Arrange, Act, and Assert.
-# https://youtu.be/sCthIEOaMI8
+# https://youtu.be/f8gjbPLFnqU
 
 # 1. Arrange -> set up the test (examples: initializing objects, let
 #               variables, updating values of instance variables).
@@ -24,7 +24,7 @@ require_relative '../lib/12_magic_seven'
 # repetition is necessary in order for them to be easy to read. If you are using
 # rubocop, you can disable specific (or all) cops for certain files (or
 # directories) by adding a .rubocop.yml file.
-# https://docs.rubocop.org/rubocop/0.88/configuration.html#includingexcluding-files
+# https://docs.rubocop.org/rubocop/configuration.html#includingexcluding-files
 
 # When you start working on an existing code base, you will often become familiar
 # with the code by reading the tests.

--- a/spec_answers/12_magic_seven_answer.rb
+++ b/spec_answers/12_magic_seven_answer.rb
@@ -8,7 +8,7 @@ require_relative '../lib/12_magic_seven'
 
 # Before learning any more complexities of testing, let's take a look at a
 # standard testing pattern: Arrange, Act, and Assert.
-# https://youtu.be/sCthIEOaMI8
+# https://youtu.be/f8gjbPLFnqU
 
 # 1. Arrange -> set up the test (examples: initializing objects, let
 #               variables, updating values of instance variables).
@@ -24,7 +24,7 @@ require_relative '../lib/12_magic_seven'
 # repetition is necessary in order for them to be easy to read. If you are using
 # rubocop, you can disable specific (or all) cops for certain files (or
 # directories) by adding a .rubocop.yml file.
-# https://docs.rubocop.org/rubocop/0.88/configuration.html#includingexcluding-files
+# https://docs.rubocop.org/rubocop/configuration.html#includingexcluding-files
 
 # When you start working on a existing code base, you will often become familiar
 # with the code by reading the tests.


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The exercise contained 2 broken links. I want to replace the links with working resources.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Replaces the non-existent A-A-A video on YouTube with a working video also covering A-A-A and Rspec
- Replaces the broken link on rubocop documentation with a working link to rubocop documentation

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #68 and #69 

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `String spec: Update instructions for clarity`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes changes in the `spec` folder, they are also updated in the corresponding file in the `spec_answers` folder (with passing tests).
