### PR TITLE
Chore: Add script for running all spec_answer tests

### DIFF
--- a/bin/test_answers
+++ b/bin/test_answers
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+
+results = Dir['spec_answers/*'].map do |spec_answer|
+  puts "running tests for #{spec_answer}"
+  system "bundle exec rspec #{spec_answer} --format progress"
+end
+
+if results.all?
+  puts 'All tests are passing!'
+else
+  puts 'Some tests are failing oh no!'
+end


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Because it's a bit annoying to run all of these at once, which is important for contributing purposes (want to make sure I don't break anything)

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds a script for running all the spec files in `spec_answers`. I use `--format progress` to keep the stdout at least a little clean. Also includes a little `puts` statement at the very end to communicate if all pass or if there were failures.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `String spec: Update instructions for clarity`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes changes in the `spec` folder, they are also updated in the corresponding file in the `spec_answers` folder (with passing tests).
